### PR TITLE
MB-54166 Fix build for 'backup' in CV caused by missing 'cbauth' dependency

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -146,6 +146,7 @@ pipeline {
         stage("Clone") {
             when {
                 expression {
+                    // Only run this step for 'tools-common', it has a slightly lighter weight build process.
                     return env.GERRIT_PROJECT == 'tools-common';
                 }
             }
@@ -163,6 +164,8 @@ pipeline {
         stage("Clone") {
             when {
                 expression {
+                    // All projects except 'tools-common' use 'repo' to clone them so ensure this step doesn't execute
+                    // for 'tools-common' as it has it's own clone step.
                     return env.GERRIT_PROJECT != 'tools-common';
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -178,7 +178,7 @@ pipeline {
                 // Initialize and sync 'backup' group using 'repo'
                 dir("${CB_SERVER_SOURCE}") {
                     sh "repo init -u https://github.com/couchbase/manifest -m ${CB_SERVER_MANIFEST} -g ${CB_SERVER_MANIFEST_GROUPS}"
-                    sh "repo sync --jobs=8"
+                    sh "repo sync --jobs=${env.PARALLELISM}"
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,10 +33,10 @@ pipeline {
     agent { label getNodeLabel() }
 
     environment {
+        EXAMINADOR = "${WORKSPACE}/examinador"
+
         CB_SERVER_SOURCE = "${WORKSPACE}/server"
         CB_SERVER_SOURCE_PROJECT = "${CB_SERVER_SOURCE}/${GERRIT_PROJECT}"
-
-        EXAMINADOR = "${WORKSPACE}/examinador"
 
         GO_TARBALL_URL = "https://golang.org/dl/go1.19.linux-amd64.tar.gz"
         GOLANGCI_LINT_VERSION = "v1.49.0"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,6 +20,7 @@ PARALLELISM = 16
 
 GO_VERSION = "1.19"
 CB_SERVER_MANIFEST = "branch-master.xml"
+CB_SERVER_MANIFEST_GROUPS = "backup"
 
 WINDOWS_NODE_LABEL = "msvc2017"
 LINUX_NODE_LABEL = "ubuntu-18.04 && large"
@@ -176,7 +177,7 @@ pipeline {
 
                 // Initialize and sync 'backup' group using 'repo'
                 dir("${CB_SERVER_SOURCE}") {
-                    sh "repo init -u https://github.com/couchbase/manifest -m ${CB_SERVER_MANIFEST} -g backup"
+                    sh "repo init -u https://github.com/couchbase/manifest -m ${CB_SERVER_MANIFEST} -g ${CB_SERVER_MANIFEST_GROUPS}"
                     sh "repo sync --jobs=8"
                 }
             }


### PR DESCRIPTION
As part of the work for MB-54166, the `backup` repository switched from a standalone build to one that requires local dependencies (cbauth).

To fix this:
1. The clone stages for `backup` and `tools-common` were separated.
2. `backup` is now clone used `repo` (with the `backup`) group.
3. The separate `CURRENT_PROJECT` and `CB_SERVER_SOURCE_PROJECT` variables have been merged (required as `backup` and `tools-common` must be in a common location to run linting et al.

This ultimately means that `backup` is cloned using `repo` and built with the expected dependencies (`cbauth`) where it wasn't previously. 

Worth noting that this change has the side-effect of cloning `tools-common` into the root of the Couchbase Server install which is fine as it will be ignored and there's no clashing project names.